### PR TITLE
Port Ironclad octet streams updates to trivial-octet-streams

### DIFF
--- a/octet-streams.lisp
+++ b/octet-streams.lisp
@@ -9,7 +9,7 @@
 
 ;;; portability definitions
 
-#+cmu
+#+(or cmu abcl)
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (require :gray-streams))
 
@@ -30,7 +30,8 @@
    #+openmcl gray:fundamental-binary-input-stream
    #+cmu ext:fundamental-binary-input-stream
    #+allegro excl:fundamental-binary-input-stream
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:fundamental-binary-input-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *binary-output-stream-class*
@@ -40,7 +41,8 @@
    #+openmcl gray:fundamental-binary-output-stream
    #+cmu ext:fundamental-binary-output-stream
    #+allegro excl:fundamental-binary-output-stream
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:fundamental-binary-output-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 ;;; FIXME: how to do CMUCL support for this?
@@ -51,7 +53,8 @@
    #+openmcl cl:stream-element-type
    #+cmu cl:stream-element-type
    #+allegro cl:stream-element-type
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl cl:stream-element-type
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-read-byte-function*
@@ -61,7 +64,8 @@
    #+openmcl gray:stream-read-byte
    #+cmu ext:stream-read-byte
    #+allegro excl:stream-read-byte
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-read-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-write-byte-function*
@@ -71,7 +75,8 @@
    #+openmcl gray:stream-write-byte
    #+cmu ext:stream-write-byte
    #+allegro excl:stream-write-byte
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-write-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-read-sequence-function*
@@ -81,7 +86,8 @@
    #+openmcl ccl:stream-read-vector
    #+cmu ext:stream-read-sequence
    #+allegro excl:stream-read-sequence
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-read-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-write-sequence-function*
@@ -91,7 +97,8 @@
    #+openmcl ccl:stream-write-vector
    #+cmu ext:stream-write-sequence
    #+allegro excl:stream-write-sequence
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-write-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-finish-output-function*
@@ -101,7 +108,8 @@
    #+openmcl gray:stream-finish-output
    #+cmu ext:stream-finish-output
    #+allegro excl:stream-finish-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-finish-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-force-output-function*
@@ -111,7 +119,8 @@
    #+openmcl gray:stream-force-output
    #+cmu ext:stream-force-output
    #+allegro excl:stream-force-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-force-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-clear-output-function*
@@ -121,7 +130,8 @@
    #+openmcl gray:stream-clear-output
    #+cmu ext:stream-clear-output
    #+allegro excl:stream-clear-output
-   #-(or lispworks sbcl openmcl cmu allegro)
+   #+abcl gray-streams:stream-clear-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl)
    (error "octet streams not supported in this implementation")))
 )
 
@@ -175,6 +185,14 @@
        (,type
         ,@body)
        (t
+        (call-next-method))))
+  #+abcl
+  `(defmethod gray-streams:stream-read-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
         (call-next-method)))))
 
 (defmacro define-stream-write-sequence (specializer type &body body)
@@ -222,6 +240,14 @@
      (typecase seq
        (,type
         ,@body)
+       (t
+        (call-next-method))))
+  #+abcl
+  `(defmethod gray-streams:stream-write-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
        (t
         (call-next-method)))))
 

--- a/octet-streams.lisp
+++ b/octet-streams.lisp
@@ -335,6 +335,9 @@
     (make-instance 'octet-input-stream
                    :buffer buffer :index start :end end)))
 
+(defmacro with-octet-input-stream ((var buffer &optional (start 0) end) &body body)
+  `(with-open-stream (,var (make-octet-input-stream ,buffer ,start ,end))
+     ,@body))
 
 ;;; output streams
 
@@ -391,3 +394,8 @@ of a string output-stream."
   "As MAKE-STRING-OUTPUT-STREAM, only with octets instead of characters."
   (make-instance 'octet-output-stream
                  :buffer (make-array 128 :element-type '(unsigned-byte 8))))
+
+(defmacro with-octet-output-stream ((var) &body body)
+  `(with-open-stream (,var (make-octet-output-stream))
+     ,@body
+     (get-output-stream-octets ,var)))

--- a/octet-streams.lisp
+++ b/octet-streams.lisp
@@ -22,6 +22,10 @@
                    'excl:stream-write-string)
     (require "streamc.fasl")))
 
+#+ecl
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (gray::redefine-cl-functions))
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
 (defvar *binary-input-stream-class*
   (quote
@@ -31,7 +35,8 @@
    #+cmu ext:fundamental-binary-input-stream
    #+allegro excl:fundamental-binary-input-stream
    #+abcl gray-streams:fundamental-binary-input-stream
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:fundamental-binary-input-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *binary-output-stream-class*
@@ -42,7 +47,8 @@
    #+cmu ext:fundamental-binary-output-stream
    #+allegro excl:fundamental-binary-output-stream
    #+abcl gray-streams:fundamental-binary-output-stream
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:fundamental-binary-output-stream
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 ;;; FIXME: how to do CMUCL support for this?
@@ -54,7 +60,8 @@
    #+cmu cl:stream-element-type
    #+allegro cl:stream-element-type
    #+abcl cl:stream-element-type
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) cl:stream-element-type
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-read-byte-function*
@@ -65,7 +72,8 @@
    #+cmu ext:stream-read-byte
    #+allegro excl:stream-read-byte
    #+abcl gray-streams:stream-read-byte
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-read-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-write-byte-function*
@@ -76,7 +84,8 @@
    #+cmu ext:stream-write-byte
    #+allegro excl:stream-write-byte
    #+abcl gray-streams:stream-write-byte
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-write-byte
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-read-sequence-function*
@@ -87,7 +96,8 @@
    #+cmu ext:stream-read-sequence
    #+allegro excl:stream-read-sequence
    #+abcl gray-streams:stream-read-sequence
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-read-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-write-sequence-function*
@@ -98,7 +108,8 @@
    #+cmu ext:stream-write-sequence
    #+allegro excl:stream-write-sequence
    #+abcl gray-streams:stream-write-sequence
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-write-sequence
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-finish-output-function*
@@ -109,7 +120,8 @@
    #+cmu ext:stream-finish-output
    #+allegro excl:stream-finish-output
    #+abcl gray-streams:stream-finish-output
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-finish-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-force-output-function*
@@ -120,7 +132,8 @@
    #+cmu ext:stream-force-output
    #+allegro excl:stream-force-output
    #+abcl gray-streams:stream-force-output
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-force-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 
 (defvar *stream-clear-output-function*
@@ -131,7 +144,8 @@
    #+cmu ext:stream-clear-output
    #+allegro excl:stream-clear-output
    #+abcl gray-streams:stream-clear-output
-   #-(or lispworks sbcl openmcl cmu allegro abcl)
+   #+(or ecl clisp) gray:stream-clear-output
+   #-(or lispworks sbcl openmcl cmu allegro abcl ecl clisp)
    (error "octet streams not supported in this implementation")))
 )
 
@@ -193,6 +207,22 @@
         (let ((end (or end (length seq))))
           ,@body))
        (t
+        (call-next-method))))
+  #+ecl
+  `(defmethod gray:stream-read-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
+        (call-next-method))))
+  #+clisp
+  `(defmethod gray:stream-read-sequence ((stream ,specializer) seq &key (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
         (call-next-method)))))
 
 (defmacro define-stream-write-sequence (specializer type &body body)
@@ -244,6 +274,22 @@
         (call-next-method))))
   #+abcl
   `(defmethod gray-streams:stream-write-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
+        (call-next-method))))
+  #+ecl
+  `(defmethod gray:stream-write-sequence ((stream ,specializer) seq &optional (start 0) end)
+     (typecase seq
+       (,type
+        (let ((end (or end (length seq))))
+          ,@body))
+       (t
+        (call-next-method))))
+  #+clisp
+  `(defmethod gray:stream-write-sequence ((stream ,specializer) seq &key (start 0) end)
      (typecase seq
        (,type
         (let ((end (or end (length seq))))

--- a/package.lisp
+++ b/package.lisp
@@ -3,4 +3,5 @@
 (cl:defpackage :trivial-octet-streams
   (:use :cl)
   (:export #:make-octet-input-stream #:make-octet-output-stream
-           #:get-output-stream-octets))
+           #:get-output-stream-octets
+           #:with-octet-input-stream #:with-octet-output-stream))


### PR DESCRIPTION
- Add ABCL support
- Add ECL support
- Add CLISP support
- Add with-octet-input-stream macro
- Add with-octet-output-stream macro
